### PR TITLE
Improve go package workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Go package
 on:
   pull_request:
     branches: [ master ]
-  push
+  push:
 
 jobs:
   build-linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Go package
 
-on: [push]
+on:
+  pull_request:
+    branches: [ master ]
+  push
 
 jobs:
   build-linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ master ]
   push:
+    branches: [ master ]
 
 jobs:
   build-linux:


### PR DESCRIPTION
Only trigger go package workflow in:
- master branch
- pull request

This is to reduce unnecessary build when the code is not ready yet to build